### PR TITLE
Bloom filter InfoAPI for all Stores

### DIFF
--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -554,6 +554,21 @@ func runQuery(
 		)
 	)
 
+	ctx, cancel := context.WithCancel(context.Background())
+	level.Debug(logger).Log("msg", "setting up periodic label names bloom filter update")
+	g.Add(func() error {
+		return runutil.Repeat(10*time.Second, ctx.Done(), func() error {
+			level.Debug(logger).Log("msg", "Starting label names bloom filter update")
+
+			proxy.UpdateLabelNamesBloom(context.Background())
+
+			level.Debug(logger).Log("msg", "Finished label names bloom filter update")
+			return nil
+		})
+	}, func(err error) {
+		cancel()
+	})
+
 	// Periodically update the store set with the addresses we see in our cluster.
 	{
 		ctx, cancel := context.WithCancel(context.Background())

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -782,12 +782,14 @@ func runQuery(
 			info.WithStoreInfoFunc(func() *infopb.StoreInfo {
 				if httpProbe.IsReady() {
 					mint, maxt := proxy.TimeRange()
+					labelNamesBloom := proxy.LabelNamesBloom()
 					return &infopb.StoreInfo{
 						MinTime:                      mint,
 						MaxTime:                      maxt,
 						SupportsSharding:             true,
 						SupportsWithoutReplicaLabels: true,
 						TsdbInfos:                    proxy.TSDBInfos(),
+						LabelNamesBloom:              infopb.NewBloomFilter(labelNamesBloom),
 					}
 				}
 				return nil

--- a/cmd/thanos/query.go
+++ b/cmd/thanos/query.go
@@ -560,7 +560,7 @@ func runQuery(
 		return runutil.Repeat(10*time.Second, ctx.Done(), func() error {
 			level.Debug(logger).Log("msg", "Starting label names bloom filter update")
 
-			proxy.UpdateLabelNamesBloom(context.Background())
+			proxy.UpdateLabelNamesBloom(ctx)
 
 			level.Debug(logger).Log("msg", "Finished label names bloom filter update")
 			return nil

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -371,7 +371,9 @@ func runReceive(
 			return runutil.Repeat(10*time.Second, ctx.Done(), func() error {
 				level.Debug(logger).Log("msg", "Starting label names bloom filter update")
 
-				proxy.UpdateLabelNamesBloom(ctx)
+				if err := proxy.UpdateLabelNamesBloom(ctx); err != nil {
+					return err
+				}
 
 				level.Debug(logger).Log("msg", "Finished label names bloom filter update")
 				return nil

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -371,7 +371,7 @@ func runReceive(
 			return runutil.Repeat(10*time.Second, ctx.Done(), func() error {
 				level.Debug(logger).Log("msg", "Starting label names bloom filter update")
 
-				proxy.UpdateLabelNamesBloom(context.Background())
+				proxy.UpdateLabelNamesBloom(ctx)
 
 				level.Debug(logger).Log("msg", "Finished label names bloom filter update")
 				return nil

--- a/cmd/thanos/receive.go
+++ b/cmd/thanos/receive.go
@@ -339,12 +339,14 @@ func runReceive(
 			info.WithStoreInfoFunc(func() *infopb.StoreInfo {
 				if httpProbe.IsReady() {
 					minTime, maxTime := proxy.TimeRange()
+					labelNamesBloom := proxy.LabelNamesBloom()
 					return &infopb.StoreInfo{
 						MinTime:                      minTime,
 						MaxTime:                      maxTime,
 						SupportsSharding:             true,
 						SupportsWithoutReplicaLabels: true,
 						TsdbInfos:                    proxy.TSDBInfos(),
+						LabelNamesBloom:              infopb.NewBloomFilter(labelNamesBloom),
 					}
 				}
 				return nil

--- a/cmd/thanos/rule.go
+++ b/cmd/thanos/rule.go
@@ -627,12 +627,14 @@ func runRule(
 			info.WithStoreInfoFunc(func() *infopb.StoreInfo {
 				if httpProbe.IsReady() {
 					mint, maxt := tsdbStore.TimeRange()
+					labelNamesBloom := tsdbStore.LabelNamesBloom()
 					return &infopb.StoreInfo{
 						MinTime:                      mint,
 						MaxTime:                      maxt,
 						SupportsSharding:             true,
 						SupportsWithoutReplicaLabels: true,
 						TsdbInfos:                    tsdbStore.TSDBInfos(),
+						LabelNamesBloom:              infopb.NewBloomFilter(labelNamesBloom),
 					}
 				}
 				return nil

--- a/cmd/thanos/store.go
+++ b/cmd/thanos/store.go
@@ -455,12 +455,14 @@ func runStore(
 		info.WithStoreInfoFunc(func() *infopb.StoreInfo {
 			if httpProbe.IsReady() {
 				mint, maxt := bs.TimeRange()
+				labelNamesBloom := bs.LabelNamesBloom()
 				return &infopb.StoreInfo{
 					MinTime:                      mint,
 					MaxTime:                      maxt,
 					SupportsSharding:             true,
 					SupportsWithoutReplicaLabels: true,
 					TsdbInfos:                    bs.TSDBInfos(),
+					LabelNamesBloom:              infopb.NewBloomFilter(labelNamesBloom),
 				}
 			}
 			return nil

--- a/pkg/bloom/bloom.go
+++ b/pkg/bloom/bloom.go
@@ -11,6 +11,7 @@ const FilterErrorRate = 0.01
 type Filter interface {
 	Test(string) bool
 	Bytes() []byte
+	Cap() uint
 }
 
 type filter struct {
@@ -61,6 +62,10 @@ func (f filter) Test(s string) bool {
 	return f.bloom.TestString(s)
 }
 
+func (f filter) Cap() uint {
+	return f.bloom.Cap()
+}
+
 type alwaysTrueFilter struct{}
 
 func NewAlwaysTrueFilter() *alwaysTrueFilter {
@@ -73,4 +78,8 @@ func (e alwaysTrueFilter) Test(s string) bool {
 
 func (e alwaysTrueFilter) Bytes() []byte {
 	return nil
+}
+
+func (e alwaysTrueFilter) Cap() uint {
+	return 1
 }

--- a/pkg/bloom/bloom.go
+++ b/pkg/bloom/bloom.go
@@ -41,7 +41,7 @@ func NewFilterForStrings(items ...string) Filter {
 	return &filter{bloom: bloomFilter}
 }
 
-func NewFilterForMapKeys(items map[string]struct{}) Filter {
+func NewFilterFromMapKeys(items map[string]struct{}) Filter {
 	bloomFilter := bloom.NewWithEstimates(uint(len(items)), FilterErrorRate)
 	for label := range items {
 		bloomFilter.AddString(label)

--- a/pkg/bloom/bloom.go
+++ b/pkg/bloom/bloom.go
@@ -17,7 +17,7 @@ type filter struct {
 	bloom *bloom.BloomFilter
 }
 
-func NewFromBytes(bloomBytes []byte) Filter {
+func NewFilterFromBytes(bloomBytes []byte) Filter {
 	if bloomBytes == nil {
 		return NewAlwaysTrueFilter()
 	}
@@ -34,6 +34,15 @@ func NewFromBytes(bloomBytes []byte) Filter {
 func NewFilterForStrings(items ...string) Filter {
 	bloomFilter := bloom.NewWithEstimates(uint(len(items)), FilterErrorRate)
 	for _, label := range items {
+		bloomFilter.AddString(label)
+	}
+
+	return &filter{bloom: bloomFilter}
+}
+
+func NewFilterForMapKeys(items map[string]struct{}) Filter {
+	bloomFilter := bloom.NewWithEstimates(uint(len(items)), FilterErrorRate)
+	for label := range items {
 		bloomFilter.AddString(label)
 	}
 

--- a/pkg/query/endpointset.go
+++ b/pkg/query/endpointset.go
@@ -830,7 +830,7 @@ func (er *endpointRef) LabelNamesBloom() bloom.Filter {
 		return bloom.NewAlwaysTrueFilter()
 	}
 
-	return bloom.NewFromBytes(er.metadata.Store.LabelNamesBloom.BloomFilterData)
+	return bloom.NewFilterFromBytes(er.metadata.Store.LabelNamesBloom.BloomFilterData)
 }
 
 func (er *endpointRef) SupportsSharding() bool {

--- a/pkg/query/internal/test-storeset-pre-v0.8.0/storeset.go
+++ b/pkg/query/internal/test-storeset-pre-v0.8.0/storeset.go
@@ -209,15 +209,7 @@ func (s *storeRef) TimeRange() (int64, int64) {
 }
 
 func (s *storeRef) LabelNamesBloom() bloom.Filter {
-	s.mtx.RLock()
-	defer s.mtx.RUnlock()
-
-	labelNames, err := s.LabelNames(context.Background(), &storepb.LabelNamesRequest{})
-	if err != nil {
-		return bloom.NewAlwaysTrueFilter()
-	}
-
-	return bloom.NewFilterForStrings(labelNames.Names...)
+	return bloom.NewAlwaysTrueFilter()
 }
 
 func (s *storeRef) SupportsSharding() bool {

--- a/pkg/query/internal/test-storeset-pre-v0.8.0/storeset.go
+++ b/pkg/query/internal/test-storeset-pre-v0.8.0/storeset.go
@@ -23,6 +23,7 @@ import (
 	"github.com/prometheus/prometheus/model/labels"
 	"google.golang.org/grpc"
 
+	"github.com/thanos-io/thanos/pkg/bloom"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/info/infopb"
 	"github.com/thanos-io/thanos/pkg/runutil"
@@ -205,6 +206,18 @@ func (s *storeRef) TimeRange() (int64, int64) {
 	defer s.mtx.RUnlock()
 
 	return s.minTime, s.maxTime
+}
+
+func (s *storeRef) LabelNamesBloom() bloom.Filter {
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	labelNames, err := s.LabelNames(context.Background(), &storepb.LabelNamesRequest{})
+	if err != nil {
+		return bloom.NewAlwaysTrueFilter()
+	}
+
+	return bloom.NewFilterForStrings(labelNames.Names...)
 }
 
 func (s *storeRef) SupportsSharding() bool {

--- a/pkg/receive/multitsdb.go
+++ b/pkg/receive/multitsdb.go
@@ -102,16 +102,6 @@ type localClient struct {
 	store *store.TSDBStore
 }
 
-func NewLocalClient(
-	c storepb.StoreClient,
-	store *store.TSDBStore,
-) store.Client {
-	return &localClient{
-		StoreClient: c,
-		store:       store,
-	}
-}
-
 func newLocalClient(c storepb.StoreClient, store *store.TSDBStore) *localClient {
 	return &localClient{
 		StoreClient: c,

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1649,7 +1649,7 @@ func (s *BucketStore) UpdateLabelNamesBloom(ctx context.Context) error {
 	g, _ := errgroup.WithContext(ctx)
 
 	var mtx sync.Mutex
-	var names map[string]struct{}
+	names := make(map[string]struct{})
 
 	for _, b := range s.blocks {
 		b := b

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -45,6 +45,7 @@ import (
 	"github.com/thanos-io/thanos/pkg/block"
 	"github.com/thanos-io/thanos/pkg/block/indexheader"
 	"github.com/thanos-io/thanos/pkg/block/metadata"
+	"github.com/thanos-io/thanos/pkg/bloom"
 	"github.com/thanos-io/thanos/pkg/compact/downsample"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/extprom"
@@ -1639,6 +1640,15 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 		Names: strutil.MergeSlices(sets...),
 		Hints: anyHints,
 	}, nil
+}
+
+func (b *BucketStore) LabelNamesBloom() bloom.Filter {
+	labelNames, err := b.LabelNames(context.Background(), &storepb.LabelNamesRequest{})
+	if err != nil {
+		return bloom.NewAlwaysTrueFilter()
+	}
+
+	return bloom.NewFilterForStrings(labelNames.Names...)
 }
 
 func (b *bucketBlock) FilterExtLabelsMatchers(matchers []*labels.Matcher) ([]*labels.Matcher, bool) {

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -1681,7 +1681,7 @@ func (s *BucketStore) UpdateLabelNamesBloom(ctx context.Context) error {
 	}
 
 	s.bmtx.Lock()
-	s.labelNamesBloom = bloom.NewFilterForMapKeys(names)
+	s.labelNamesBloom = bloom.NewFilterFromMapKeys(names)
 	s.bmtx.Unlock()
 
 	return nil

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -358,6 +358,9 @@ type BucketStore struct {
 
 	enableChunkHashCalculation bool
 
+	bmtx            sync.Mutex
+	labelNamesBloom bloom.Filter
+
 	blockEstimatedMaxSeriesFunc BlockEstimator
 	blockEstimatedMaxChunkFunc  BlockEstimator
 }
@@ -1642,13 +1645,53 @@ func (s *BucketStore) LabelNames(ctx context.Context, req *storepb.LabelNamesReq
 	}, nil
 }
 
-func (b *BucketStore) LabelNamesBloom() bloom.Filter {
-	labelNames, err := b.LabelNames(context.Background(), &storepb.LabelNamesRequest{})
-	if err != nil {
-		return bloom.NewAlwaysTrueFilter()
+func (s *BucketStore) UpdateLabelNamesBloom(ctx context.Context) error {
+	g, _ := errgroup.WithContext(ctx)
+
+	var mtx sync.Mutex
+	var names map[string]struct{}
+
+	for _, b := range s.blocks {
+		b := b
+		indexr := b.indexReader()
+
+		g.Go(func() error {
+			defer runutil.CloseWithLogOnErr(b.logger, indexr, "label names")
+
+			var result []string
+			res, err := indexr.block.indexHeaderReader.LabelNames()
+			if err != nil {
+				return errors.Wrapf(err, "label names for block %s", b.meta.ULID)
+			}
+
+			if len(res) > 0 {
+				mtx.Lock()
+				for _, n := range result {
+					names[n] = struct{}{}
+				}
+				mtx.Unlock()
+			}
+
+			return nil
+		})
 	}
 
-	return bloom.NewFilterForStrings(labelNames.Names...)
+	if err := g.Wait(); err != nil {
+		return err
+	}
+
+	s.bmtx.Lock()
+	s.labelNamesBloom = bloom.NewFilterForMapKeys(names)
+	s.bmtx.Unlock()
+
+	return nil
+}
+
+func (b *BucketStore) LabelNamesBloom() bloom.Filter {
+	b.bmtx.Lock()
+	defer b.bmtx.Unlock()
+
+	return b.labelNamesBloom
 }
 
 func (b *bucketBlock) FilterExtLabelsMatchers(matchers []*labels.Matcher) ([]*labels.Matcher, bool) {

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -291,11 +291,13 @@ func (s *ProxyStore) UpdateLabelNamesBloom(ctx context.Context) error {
 		g, gctx = errgroup.WithContext(ctx)
 	)
 
+	names = make(map[string]struct{})
 	for _, st := range s.stores() {
 		st := st
 
 		g.Go(func() error {
-			resp, err := st.LabelNames(gctx, &storepb.LabelNamesRequest{})
+			mint, maxt := st.TimeRange()
+			resp, err := st.LabelNames(gctx, &storepb.LabelNamesRequest{Start: mint, End: maxt, PartialResponseDisabled: true})
 			if err != nil {
 				return errors.Wrapf(err, "fetch label names from store for updating bloom filter %s", st)
 			}

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -18,7 +18,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/prometheus/prometheus/model/labels"
-	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -316,7 +315,7 @@ func (s *ProxyStore) UpdateLabelNamesBloom(ctx context.Context) error {
 	}
 
 	s.mtx.Lock()
-	s.labelNamesBloom = bloom.NewFilterForStrings(maps.Keys(names)...)
+	s.labelNamesBloom = bloom.NewFilterForMapKeys(names)
 	s.mtx.Unlock()
 
 	return nil

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -317,7 +317,7 @@ func (s *ProxyStore) UpdateLabelNamesBloom(ctx context.Context) error {
 	}
 
 	s.mtx.Lock()
-	s.labelNamesBloom = bloom.NewFilterForMapKeys(names)
+	s.labelNamesBloom = bloom.NewFilterFromMapKeys(names)
 	s.mtx.Unlock()
 
 	return nil

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -274,6 +274,15 @@ func (s *ProxyStore) TSDBInfos() []infopb.TSDBInfo {
 	return infos
 }
 
+func (s *ProxyStore) LabelNamesBloom() bloom.Filter {
+	labelNames, err := s.LabelNames(context.Background(), &storepb.LabelNamesRequest{})
+	if err != nil {
+		return bloom.NewAlwaysTrueFilter()
+	}
+
+	return bloom.NewFilterForStrings(labelNames.Names...)
+}
+
 func (s *ProxyStore) Series(originalRequest *storepb.SeriesRequest, srv storepb.Store_SeriesServer) error {
 	// TODO(bwplotka): This should be part of request logger, otherwise it does not make much sense. Also, could be
 	// tiggered by tracing span to reduce cognitive load.

--- a/pkg/store/proxy_heap.go
+++ b/pkg/store/proxy_heap.go
@@ -899,6 +899,12 @@ type respSet interface {
 // external label for the given Client.
 func hasInternalReplicaLabels(st Client, req *storepb.SeriesRequest) bool {
 	bloom := st.LabelNamesBloom()
+	// Empty bloom filter capacity is 1. We fallback to eager retrieval if bloom filter
+	// is yet to be updated, as we cannot yet determine if the store has internal replica labels.
+	if bloom.Cap() <= 1 {
+		return true
+	}
+
 	for _, labelName := range req.WithoutReplicaLabels {
 		if bloom.Test(labelName) {
 			return true

--- a/pkg/store/tsdb.go
+++ b/pkg/store/tsdb.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
+	"github.com/thanos-io/thanos/pkg/bloom"
 	"github.com/thanos-io/thanos/pkg/component"
 	"github.com/thanos-io/thanos/pkg/info/infopb"
 	"github.com/thanos-io/thanos/pkg/runutil"
@@ -367,4 +368,13 @@ func (s *TSDBStore) LabelValues(ctx context.Context, r *storepb.LabelValuesReque
 	}
 
 	return &storepb.LabelValuesResponse{Values: values}, nil
+}
+
+func (s *TSDBStore) LabelNamesBloom() bloom.Filter {
+	labelNames, err := s.LabelNames(context.Background(), &storepb.LabelNamesRequest{})
+	if err != nil {
+		return bloom.NewAlwaysTrueFilter()
+	}
+
+	return bloom.NewFilterForStrings(labelNames.Names...)
 }

--- a/test/e2e/e2ethanos/services.go
+++ b/test/e2e/e2ethanos/services.go
@@ -37,7 +37,8 @@ import (
 )
 
 const (
-	infoLogLevel = "info"
+	infoLogLevel  = "info"
+	debugLogLevel = "debug"
 )
 
 // Same as default for now.

--- a/test/e2e/query_test.go
+++ b/test/e2e/query_test.go
@@ -988,6 +988,27 @@ func TestQueryStoreDedup(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	t.Cleanup(cancel)
 
+	bucket := "store-gw-dedup-test"
+	minio := e2edb.NewMinio(e, "thanos-minio", bucket, e2edb.WithMinioTLS())
+	testutil.Ok(t, e2e.StartAndWaitReady(minio))
+
+	l := log.NewLogfmtLogger(os.Stdout)
+	bkt, err := s3.NewBucketWithConfig(l, e2ethanos.NewS3Config(bucket, minio.Endpoint("http"), minio.Dir()), "test")
+	testutil.Ok(t, err)
+
+	storeGW := e2ethanos.NewStoreGW(
+		e,
+		"s1",
+		client.BucketConfig{
+			Type:   client.S3,
+			Config: e2ethanos.NewS3Config(bucket, minio.InternalEndpoint("http"), minio.InternalDir()),
+		},
+		"",
+		"",
+		nil,
+	)
+	testutil.Ok(t, e2e.StartAndWaitReady(storeGW))
+
 	tests := []struct {
 		extReplicaLabel  string
 		intReplicaLabel  string
@@ -1122,33 +1143,16 @@ func TestQueryStoreDedup(t *testing.T) {
 		},
 	}
 
+	// Prepare and upload all the blocks that will be used to S3.
+	var totalBlocks int
+	for _, tt := range tests {
+		createSimpleReplicatedBlocksInS3(ctx, t, e, l, bkt, tt.series, tt.blockFinderLabel)
+		totalBlocks += len(tt.series)
+	}
+	testutil.Ok(t, storeGW.WaitSumMetrics(e2emon.Equals(float64(totalBlocks)), "thanos_blocks_meta_synced"))
+
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			bucket := "store-gw-" + tt.blockFinderLabel
-			minio := e2edb.NewMinio(e, "thanos-minio"+tt.blockFinderLabel, bucket, e2edb.WithMinioTLS())
-			testutil.Ok(t, e2e.StartAndWaitReady(minio))
-
-			l := log.NewLogfmtLogger(os.Stdout)
-			bkt, err := s3.NewBucketWithConfig(l, e2ethanos.NewS3Config(bucket, minio.Endpoint("http"), minio.Dir()), "test")
-			testutil.Ok(t, err)
-
-			storeGW := e2ethanos.NewStoreGW(
-				e,
-				"s1"+tt.blockFinderLabel,
-				client.BucketConfig{
-					Type:   client.S3,
-					Config: e2ethanos.NewS3Config(bucket, minio.InternalEndpoint("http"), minio.InternalDir()),
-				},
-				"",
-				"",
-				nil,
-			)
-			testutil.Ok(t, e2e.StartAndWaitReady(storeGW))
-
-			// Prepare and upload all the blocks that will be used to S3.
-			createSimpleReplicatedBlocksInS3(ctx, t, e, l, bkt, tt.series, tt.blockFinderLabel)
-			testutil.Ok(t, storeGW.WaitSumMetrics(e2emon.Equals(float64(len(tt.series))), "thanos_blocks_meta_synced"))
-
 			querierBuilder := e2ethanos.NewQuerierBuilder(e, tt.blockFinderLabel, storeGW.InternalEndpoint("grpc")).WithProxyStrategy("lazy")
 			var replicaLabels []string
 			if tt.intReplicaLabel != "" {

--- a/test/e2e/receive_test.go
+++ b/test/e2e/receive_test.go
@@ -233,13 +233,13 @@ test_metric{a="2", b="2"} 1`)
 			},
 		})
 
-		// This should've returned only 2 series, but is returning 4 until the problem reported in
-		// https://github.com/thanos-io/thanos/issues/6257 is fixed
+		// This is a regression test for the bug outlined in https://github.com/thanos-io/thanos/issues/6257.
+		// Until the bug was fixed, this testcase would return 4 series instead of 2.
 		instantQuery(t, ctx, qStatic.Endpoint("http"), func() string {
 			return "test_metric"
 		}, time.Now, promclient.QueryOptions{
 			Deduplicate: true,
-		}, 4)
+		}, 2)
 	})
 
 	t.Run("router_replication", func(t *testing.T) {
@@ -755,7 +755,6 @@ test_metric{a="2", b="2"} 1`)
 	})
 
 	t.Run("multitenant_active_series_limiting", func(t *testing.T) {
-
 		/*
 			The multitenant_active_series_limiting suite configures a hashring with
 			two avalanche writers and dedicated meta-monitoring.


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->
- Added some boilerplate, and modified the tests.
- Polling and caching of LabelNames bloom filter similar to Sidecar for other stores
- Union of label names for stores with multiple clients

TODO:
- Fix and add unit tests

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

<!-- Enumerate changes you made -->

## Verification

<!-- How you tested it? How do you know it works? -->
