### PR TITLE
Feature flag & add basic unit tests for Proxy/BlockStore UpdateLabelNamesBloom()

### DIFF
--- a/pkg/bloom/bloom.go
+++ b/pkg/bloom/bloom.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package bloom
 
 import (

--- a/pkg/info/infopb/custom.go
+++ b/pkg/info/infopb/custom.go
@@ -1,3 +1,6 @@
+// Copyright (c) The Thanos Authors.
+// Licensed under the Apache License 2.0.
+
 package infopb
 
 import (

--- a/pkg/store/bucket.go
+++ b/pkg/store/bucket.go
@@ -507,6 +507,7 @@ func NewBucketStore(
 		enableSeriesResponseHints:   enableSeriesResponseHints,
 		enableChunkHashCalculation:  enableChunkHashCalculation,
 		seriesBatchSize:             SeriesBatchSize,
+		labelNamesBloom:             bloom.NewAlwaysTrueFilter(),
 	}
 
 	for _, option := range options {
@@ -1667,11 +1668,13 @@ func (s *BucketStore) UpdateLabelNamesBloom(ctx context.Context) error {
 				extRes = append(extRes, l.Name)
 			}
 
-			res = strutil.MergeSlices(res, extRes)
-
 			if len(res) > 0 {
 				mtx.Lock()
 				for _, n := range res {
+					names[n] = struct{}{}
+				}
+
+				for _, n := range extRes {
 					names[n] = struct{}{}
 				}
 				mtx.Unlock()

--- a/pkg/store/proxy.go
+++ b/pkg/store/proxy.go
@@ -154,6 +154,7 @@ func NewProxyStore(
 		responseTimeout:     responseTimeout,
 		metrics:             metrics,
 		retrievalStrategy:   retrievalStrategy,
+		labelNamesBloom:     bloom.NewAlwaysTrueFilter(),
 		internalLabelResort: true,
 	}
 

--- a/pkg/store/proxy_heap.go
+++ b/pkg/store/proxy_heap.go
@@ -906,7 +906,7 @@ func hasInternalReplicaLabels(st Client, req *storepb.SeriesRequest, internalLab
 	bloom := st.LabelNamesBloom()
 	// Empty bloom filter capacity is 1. We fallback to eager retrieval if bloom filter
 	// is yet to be updated, as we cannot yet determine if the store has internal replica labels.
-	if bloom == nil || bloom.Cap() <= 1 {
+	if bloom.Cap() <= 1 {
 		return true
 	}
 

--- a/pkg/store/proxy_heap.go
+++ b/pkg/store/proxy_heap.go
@@ -901,7 +901,7 @@ func hasInternalReplicaLabels(st Client, req *storepb.SeriesRequest) bool {
 	bloom := st.LabelNamesBloom()
 	// Empty bloom filter capacity is 1. We fallback to eager retrieval if bloom filter
 	// is yet to be updated, as we cannot yet determine if the store has internal replica labels.
-	if bloom.Cap() <= 1 {
+	if bloom == nil || bloom.Cap() <= 1 {
 		return true
 	}
 

--- a/pkg/store/proxy_test.go
+++ b/pkg/store/proxy_test.go
@@ -1604,7 +1604,7 @@ func TestProxyStore_LabelNamesBloom(t *testing.T) {
 		expectedNames []string
 	}{
 		{
-			title: "label_names partial response disabled",
+			title: "some common labels",
 			storeAPIs: []Client{
 				&storetestutil.TestClient{
 					StoreClient: &mockedStoreAPI{
@@ -1622,6 +1622,100 @@ func TestProxyStore_LabelNamesBloom(t *testing.T) {
 				},
 			},
 			expectedNames: []string{"a", "b", "c", "d"},
+		},
+		{
+			title: "fully common labels",
+			storeAPIs: []Client{
+				&storetestutil.TestClient{
+					StoreClient: &mockedStoreAPI{
+						RespLabelNames: &storepb.LabelNamesResponse{
+							Names: []string{"a", "b"},
+						},
+					},
+				},
+				&storetestutil.TestClient{
+					StoreClient: &mockedStoreAPI{
+						RespLabelNames: &storepb.LabelNamesResponse{
+							Names: []string{"a", "b"},
+						},
+					},
+				},
+			},
+			expectedNames: []string{"a", "b"},
+		},
+		{
+			title: "no common labels",
+			storeAPIs: []Client{
+				&storetestutil.TestClient{
+					StoreClient: &mockedStoreAPI{
+						RespLabelNames: &storepb.LabelNamesResponse{
+							Names: []string{"a", "b"},
+						},
+					},
+				},
+				&storetestutil.TestClient{
+					StoreClient: &mockedStoreAPI{
+						RespLabelNames: &storepb.LabelNamesResponse{
+							Names: []string{"c", "d"},
+						},
+					},
+				},
+			},
+			expectedNames: []string{"a", "b", "c", "d"},
+		},
+		{
+			title: "multiple stores",
+			storeAPIs: []Client{
+				&storetestutil.TestClient{
+					StoreClient: &mockedStoreAPI{
+						RespLabelNames: &storepb.LabelNamesResponse{
+							Names: []string{"a", "b"},
+						},
+					},
+				},
+				&storetestutil.TestClient{
+					StoreClient: &mockedStoreAPI{
+						RespLabelNames: &storepb.LabelNamesResponse{
+							Names: []string{"c", "d"},
+						},
+					},
+				},
+				&storetestutil.TestClient{
+					StoreClient: &mockedStoreAPI{
+						RespLabelNames: &storepb.LabelNamesResponse{
+							Names: []string{"e", "f"},
+						},
+					},
+				},
+			},
+			expectedNames: []string{"a", "b", "c", "d", "e", "f"},
+		},
+		{
+			title: "empty store",
+			storeAPIs: []Client{
+				&storetestutil.TestClient{
+					StoreClient: &mockedStoreAPI{
+						RespLabelNames: &storepb.LabelNamesResponse{
+							Names: []string{},
+						},
+					},
+				},
+				&storetestutil.TestClient{
+					StoreClient: &mockedStoreAPI{
+						RespLabelNames: &storepb.LabelNamesResponse{
+							Names: []string{"c", "d"},
+						},
+					},
+				},
+				&storetestutil.TestClient{
+					StoreClient: &mockedStoreAPI{
+						RespLabelNames: &storepb.LabelNamesResponse{
+							Names: []string{"e", "f"},
+						},
+					},
+				},
+			},
+			expectedNames: []string{"c", "d", "e", "f"},
 		},
 	} {
 		if ok := t.Run(tc.title, func(t *testing.T) {


### PR DESCRIPTION
<!--
    Keep PR title verbose enough and add prefix telling
    about what components it touches e.g "query:" or ".*:"
-->

<!--
    Don't forget about CHANGELOG!

    Changelog entry format:
    - [#<PR-id>](<PR-URL>) Thanos <Component> ...

    <PR-id> Id of your pull request.
    <PR-URL> URL of your PR such as https://github.com/thanos-io/thanos/pull/<PR-id>
    <Component> Component affected by your changes such as Query, Store, Receive.
-->

* [ ] I added CHANGELOG entry for this change.
* [ ] Change is not relevant to the end user.

## Changes

- Adds unit tests for Proxy and BlockStore bloom filter routine
- Also, fixes some edge cases and lint
- Adds feature flag for proxyStore internal label resort that defaults to true

## Verification

<!-- How you tested it? How do you know it works? -->
